### PR TITLE
simplify tierd_vpc_ng output

### DIFF
--- a/networking/intra_vpc_security_group_rule_for_tiered_vpc_ng/README.md
+++ b/networking/intra_vpc_security_group_rule_for_tiered_vpc_ng/README.md
@@ -13,14 +13,14 @@ This Intra VPC Security Group Rule will create a SG Rule for each Tiered VPC all
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 1.0.4 |
-| aws | ~> 3.53.0 |
+| terraform | ~> 1 |
+| aws | ~> 3.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.53.0 |
+| aws | ~> 3.53 |
 
 ## Inputs
 

--- a/networking/intra_vpc_security_group_rule_for_tiered_vpc_ng/versions.tf
+++ b/networking/intra_vpc_security_group_rule_for_tiered_vpc_ng/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "~> 1.0.4"
+  required_version = "~> 1"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.53.0"
+      version = "~> 3.53"
     }
   }
 }

--- a/networking/tiered_vpc_ng/README.md
+++ b/networking/tiered_vpc_ng/README.md
@@ -43,14 +43,14 @@ What’s new in NG?
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 1.0.4 |
-| aws | ~> 3.53.0 |
+| terraform | ~> 1 |
+| aws | ~> 3.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.53.0 |
+| aws | ~> 3.53 |
 | random | n/a |
 
 ## Inputs

--- a/networking/tiered_vpc_ng/outputs.tf
+++ b/networking/tiered_vpc_ng/outputs.tf
@@ -16,13 +16,11 @@ output "intra_vpc_security_group_id" {
 }
 
 locals {
-  private_subnet_to_subnet_id   = { for subnet, this in aws_subnet.private : subnet => this.id }
-  private_subnet_ids_per_az     = { for subnet, private_subnet_id in local.private_subnet_to_subnet_id : lookup(local.private_subnet_to_az, subnet) => private_subnet_id... } # group subnet_ids by AZ of subnet
+  private_subnet_ids_per_az     = { for subnet, this in aws_subnet.private : lookup(local.private_subnet_to_az, subnet) => this.id... } # group subnet_ids by AZ of subnet
   private_route_table_id_per_az = { for az, route_table in aws_route_table.private : az => route_table.id }
 
-  public_subnet_to_subnet_id   = { for subnet, this in aws_subnet.public : subnet => this.id }
-  public_subnet_ids_per_az     = { for subnet, public_subnet_id in local.public_subnet_to_subnet_id : lookup(local.public_subnet_to_az, subnet) => public_subnet_id... } # group subnet_ids by AZ of subnet
-  public_route_table_id_per_az = { for az, subnet_id in local.public_subnet_ids_per_az : az => aws_route_table.public.id }                                               # Each public subnet shares the same route table
+  public_subnet_ids_per_az     = { for subnet, this in aws_subnet.public : lookup(local.public_subnet_to_az, subnet) => this.id... } # group subnet_ids by AZ of subnet
+  public_route_table_id_per_az = { for az, subnet_id in local.public_subnet_ids_per_az : az => aws_route_table.public.id }           # Each public subnet shares the same route table
 }
 
 output "az_to_private_subnet_ids" {

--- a/networking/tiered_vpc_ng/outputs.tf
+++ b/networking/tiered_vpc_ng/outputs.tf
@@ -16,25 +16,25 @@ output "intra_vpc_security_group_id" {
 }
 
 locals {
-  private_subnet_ids_per_az     = { for subnet, this in aws_subnet.private : lookup(local.private_subnet_to_az, subnet) => this.id... } # group subnet_ids by AZ of subnet
-  private_route_table_id_per_az = { for az, route_table in aws_route_table.private : az => route_table.id }
+  az_to_private_subnet_ids     = { for subnet, this in aws_subnet.private : lookup(local.private_subnet_to_az, subnet) => this.id... } # group subnet_ids by AZ of subnet
+  az_to_private_route_table_id = { for az, route_table in aws_route_table.private : az => route_table.id }
 
-  public_subnet_ids_per_az     = { for subnet, this in aws_subnet.public : lookup(local.public_subnet_to_az, subnet) => this.id... } # group subnet_ids by AZ of subnet
-  public_route_table_id_per_az = { for az, subnet_id in local.public_subnet_ids_per_az : az => aws_route_table.public.id }           # Each public subnet shares the same route table
+  az_to_public_subnet_ids     = { for subnet, this in aws_subnet.public : lookup(local.public_subnet_to_az, subnet) => this.id... } # group subnet_ids by AZ of subnet
+  az_to_public_route_table_id = { for az, subnet_id in local.az_to_public_subnet_ids : az => aws_route_table.public.id }            # Each public subnet shares the same route table
 }
 
 output "az_to_private_subnet_ids" {
-  value = local.private_subnet_ids_per_az
+  value = local.az_to_private_subnet_ids
 }
 
 output "az_to_private_route_table_id" {
-  value = local.private_route_table_id_per_az
+  value = local.az_to_private_route_table_id
 }
 
 output "az_to_public_subnet_ids" {
-  value = local.public_subnet_ids_per_az
+  value = local.az_to_public_subnet_ids
 }
 
 output "az_to_public_route_table_id" {
-  value = local.public_route_table_id_per_az
+  value = local.az_to_public_route_table_id
 }

--- a/networking/tiered_vpc_ng/versions.tf
+++ b/networking/tiered_vpc_ng/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "~> 1.0.4"
+  required_version = "~> 1"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.53.0"
+      version = "~> 3.53"
     }
   }
   # needed for utilizing optional() and defaults() until they're GA

--- a/networking/transit_gateway_centralized_router_for_tiered_vpc_ng/README.md
+++ b/networking/transit_gateway_centralized_router_for_tiered_vpc_ng/README.md
@@ -16,14 +16,14 @@ the TGW.
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 1.0.4 |
-| aws | ~> 3.53.0 |
+| terraform | ~> 1 |
+| aws | ~> 3.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.53.0 |
+| aws | ~> 3.53 |
 
 ## Inputs
 

--- a/networking/transit_gateway_centralized_router_for_tiered_vpc_ng/versions.tf
+++ b/networking/transit_gateway_centralized_router_for_tiered_vpc_ng/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "~> 1.0.4"
+  required_version = "~> 1"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.53.0"
+      version = "~> 3.53"
     }
   }
 }


### PR DESCRIPTION
- remove unnecessary layer of iteration.
- make versioning less strict.
- need to test.