### PR TITLE
make current tgw route generation more efficient in super router

### DIFF
--- a/networking/tgw_super_router_for_tgw_centralized_router/routing.tf
+++ b/networking/tgw_super_router_for_tgw_centralized_router/routing.tf
@@ -83,9 +83,9 @@ locals {
 
   # build new local vpc routes to other peer tgws
   local_vpc_routes_to_peer_tgws = [
-    for rtb_id_and_peer_tgw_network_cidr in setproduct(local.local_tgws_all_vpc_routes[*].route_table_id, local.peer_tgws_all_vpc_network_cidrs) : {
-      route_table_id         = rtb_id_and_peer_tgw_network_cidr[0]
-      destination_cidr_block = rtb_id_and_peer_tgw_network_cidr[1]
+    for route_table_id_and_peer_tgw_network_cidr in setproduct(local.local_tgws_all_vpc_routes[*].route_table_id, local.peer_tgws_all_vpc_network_cidrs) : {
+      route_table_id         = route_table_id_and_peer_tgw_network_cidr[0]
+      destination_cidr_block = route_table_id_and_peer_tgw_network_cidr[1]
   }]
 
   local_tgw_all_new_vpc_routes_to_peer_tgws = {
@@ -107,9 +107,9 @@ resource "aws_route" "this_local_vpc_routes_to_peer_tgws" {
 locals {
   # build new local vpc routes to other local vpcs
   local_vpc_routes_to_local_tgws = [
-    for rtb_id_and_local_tgw_network_cidr in setproduct(local.local_tgws_all_vpc_routes[*].route_table_id, local.local_tgws_all_vpc_network_cidrs) : {
-      route_table_id         = rtb_id_and_local_tgw_network_cidr[0]
-      destination_cidr_block = rtb_id_and_local_tgw_network_cidr[1]
+    for route_table_id_and_local_tgw_network_cidr in setproduct(local.local_tgws_all_vpc_routes[*].route_table_id, local.local_tgws_all_vpc_network_cidrs) : {
+      route_table_id         = route_table_id_and_local_tgw_network_cidr[0]
+      destination_cidr_block = route_table_id_and_local_tgw_network_cidr[1]
   }]
 
   # subtract all current existing local vpc routes from all local vpc routes
@@ -134,9 +134,9 @@ locals {
 
   # build new local tgw routes to other peer tgws
   local_tgw_routes_to_peer_tgws = [
-    for rtb_id_and_peer_tgw_network_cidr in setproduct(local.local_tgws[*].route_table_id, local.peer_tgws_all_vpc_network_cidrs) : {
-      route_table_id         = rtb_id_and_peer_tgw_network_cidr[0]
-      destination_cidr_block = rtb_id_and_peer_tgw_network_cidr[1]
+    for route_table_id_and_peer_tgw_network_cidr in setproduct(local.local_tgws[*].route_table_id, local.peer_tgws_all_vpc_network_cidrs) : {
+      route_table_id         = route_table_id_and_peer_tgw_network_cidr[0]
+      destination_cidr_block = route_table_id_and_peer_tgw_network_cidr[1]
   }]
 
   local_tgw_all_new_tgw_routes_to_vpcs_in_peer_tgws = {
@@ -162,19 +162,18 @@ resource "aws_ec2_transit_gateway_route" "this_local_tgw_routes_to_vpcs_in_peer_
 locals {
   # build new local tgw routes to other local tgws
   local_tgws_routes_to_local_tgws = [
-    for rtb_id_and_network_cidr in setproduct(local.local_tgws[*].route_table_id, local.local_tgws_all_vpc_network_cidrs) : {
-      route_table_id         = rtb_id_and_network_cidr[0]
-      destination_cidr_block = rtb_id_and_network_cidr[1]
+    for route_table_id_and_network_cidr in setproduct(local.local_tgws[*].route_table_id, local.local_tgws_all_vpc_network_cidrs) : {
+      route_table_id         = route_table_id_and_network_cidr[0]
+      destination_cidr_block = route_table_id_and_network_cidr[1]
   }]
 
   # generate current existing local tgw routes for its local vpcs
   local_current_tgw_routes = flatten([
     for this in local.local_tgws : [
-      for vpc_network_cidr in this.vpc.network_cidrs : [
-        for rtb_id_and_network_cidr in setproduct(this[*].route_table_id, [vpc_network_cidr]) : {
-          route_table_id         = rtb_id_and_network_cidr[0]
-          destination_cidr_block = rtb_id_and_network_cidr[1]
-  }]]])
+      for route_table_id_and_network_cidr in setproduct(this[*].route_table_id, this.vpc.network_cidrs) : {
+        route_table_id         = route_table_id_and_network_cidr[0]
+        destination_cidr_block = route_table_id_and_network_cidr[1]
+  }]])
 
   # subtract current existing local tgw routes from all local tgw routes
   local_tgw_all_new_tgw_routes_to_local_tgws = {
@@ -266,9 +265,9 @@ locals {
 
   # build new peer vpc routes to other local tgws
   peer_vpc_routes_to_local_tgws = [
-    for rtb_id_and_peer_tgw_network_cidr in setproduct(local.peer_tgws_all_vpc_routes[*].route_table_id, local.local_tgws_all_vpc_network_cidrs) : {
-      route_table_id         = rtb_id_and_peer_tgw_network_cidr[0]
-      destination_cidr_block = rtb_id_and_peer_tgw_network_cidr[1]
+    for route_table_id_and_peer_tgw_network_cidr in setproduct(local.peer_tgws_all_vpc_routes[*].route_table_id, local.local_tgws_all_vpc_network_cidrs) : {
+      route_table_id         = route_table_id_and_peer_tgw_network_cidr[0]
+      destination_cidr_block = route_table_id_and_peer_tgw_network_cidr[1]
   }]
 
   peer_tgw_all_new_vpc_routes_to_local_tgws = {
@@ -290,9 +289,9 @@ resource "aws_route" "this_peer_vpc_routes_to_local_tgws" {
 locals {
   # build new peer vpc routes to other peer vpcs
   peer_vpc_routes_to_peer_tgws = [
-    for rtb_id_and_peer_tgw_network_cidr in setproduct(local.peer_tgws_all_vpc_routes[*].route_table_id, local.peer_tgws_all_vpc_network_cidrs) : {
-      route_table_id         = rtb_id_and_peer_tgw_network_cidr[0]
-      destination_cidr_block = rtb_id_and_peer_tgw_network_cidr[1]
+    for route_table_id_and_peer_tgw_network_cidr in setproduct(local.peer_tgws_all_vpc_routes[*].route_table_id, local.peer_tgws_all_vpc_network_cidrs) : {
+      route_table_id         = route_table_id_and_peer_tgw_network_cidr[0]
+      destination_cidr_block = route_table_id_and_peer_tgw_network_cidr[1]
   }]
 
   # subtract current existing local vpc routes from all local vpc routes
@@ -317,9 +316,9 @@ locals {
 
   # build new peer tgw routes to other peer tgws
   peer_tgw_routes_to_local_tgws = [
-    for rtb_id_and_peer_tgw_network_cidr in setproduct(local.peer_tgws[*].route_table_id, local.local_tgws_all_vpc_network_cidrs) : {
-      route_table_id         = rtb_id_and_peer_tgw_network_cidr[0]
-      destination_cidr_block = rtb_id_and_peer_tgw_network_cidr[1]
+    for route_table_id_and_peer_tgw_network_cidr in setproduct(local.peer_tgws[*].route_table_id, local.local_tgws_all_vpc_network_cidrs) : {
+      route_table_id         = route_table_id_and_peer_tgw_network_cidr[0]
+      destination_cidr_block = route_table_id_and_peer_tgw_network_cidr[1]
   }]
 
   peer_tgw_all_new_tgw_routes_to_vpcs_in_local_tgws = {
@@ -345,19 +344,18 @@ resource "aws_ec2_transit_gateway_route" "this_peer_tgw_routes_to_vpcs_in_peer_t
 locals {
   # build new peer tgw routes to other peer tgws
   peer_tgws_routes_to_peer_tgws = [
-    for rtb_id_and_network_cidr in setproduct(local.peer_tgws[*].route_table_id, local.peer_tgws_all_vpc_network_cidrs) : {
-      route_table_id         = rtb_id_and_network_cidr[0]
-      destination_cidr_block = rtb_id_and_network_cidr[1]
+    for route_table_id_and_network_cidr in setproduct(local.peer_tgws[*].route_table_id, local.peer_tgws_all_vpc_network_cidrs) : {
+      route_table_id         = route_table_id_and_network_cidr[0]
+      destination_cidr_block = route_table_id_and_network_cidr[1]
   }]
 
   # generate current existing peer tgw routes for its peer vpcs
   peer_current_tgw_routes = flatten([
     for this in local.peer_tgws : [
-      for vpc_network_cidr in this.vpc.network_cidrs : [
-        for rtb_id_and_network_cidr in setproduct(this[*].route_table_id, [vpc_network_cidr]) : {
-          route_table_id         = rtb_id_and_network_cidr[0]
-          destination_cidr_block = rtb_id_and_network_cidr[1]
-  }]]])
+      for route_table_id_and_network_cidr in setproduct(this[*].route_table_id, this.vpc.network_cidrs) : {
+        route_table_id         = route_table_id_and_network_cidr[0]
+        destination_cidr_block = route_table_id_and_network_cidr[1]
+  }]])
 
   # subtract current existing peer tgw routes from all peer tgw routes
   peer_tgw_all_new_tgw_routes_to_peer_tgws = {


### PR DESCRIPTION
- make current tgw route generation more efficient with one less for loop for local and peers
- and fix naming for everywhere else

```
  # generate current existing local tgw routes for its local vpcs
  local_current_tgw_routes = flatten([
    for this in local.local_tgws : [
      for vpc_network_cidr in this.vpc.network_cidrs : [
        for rtb_id_and_network_cidr in setproduct(this[*].route_table_id, [vpc_network_cidr]) : {
          route_table_id         = rtb_id_and_network_cidr[0]
          destination_cidr_block = rtb_id_and_network_cidr[1]
  }]]])

```