### PR TITLE
fix leaky abstraction

### DIFF
--- a/networking/tgw_super_router_for_tgw_centralized_router/routing.tf
+++ b/networking/tgw_super_router_for_tgw_centralized_router/routing.tf
@@ -118,7 +118,6 @@ locals {
       destination_cidr_block = route_table_id_and_local_tgw_network_cidr[1]
   }]
 
-  #local_tgws_all_vpc_routes_route_table_ids     = local.local_tgws_all_vpc_routes[*].route_table_id
   # generate current existing local vpc routes
   local_current_vpc_routes = flatten([
     for this in local.local_tgws : [

--- a/networking/tgw_super_router_for_tgw_centralized_router/routing.tf
+++ b/networking/tgw_super_router_for_tgw_centralized_router/routing.tf
@@ -1,7 +1,8 @@
 locals {
+  route_format = "%s|%s"
+
   local_tgws_all_vpc_network_cidrs              = flatten(local.local_tgws[*].vpc.network_cidrs)
   local_tgws_all_vpc_routes                     = flatten(local.local_tgws[*].vpc.routes)
-  local_tgws_all_current_local_only_vpc_routes  = flatten(local.local_tgws[*].vpc.current_local_only_routes)
   local_tgws_all_vpc_routes_route_table_ids     = local.local_tgws_all_vpc_routes[*].route_table_id
   local_tgws_all_vpc_routes_transit_gateway_ids = local.local_tgws_all_vpc_routes[*].transit_gateway_id
   local_tgws_all_route_table_ids                = local.local_tgws[*].route_table_id
@@ -9,13 +10,10 @@ locals {
 
   peer_tgws_all_vpc_network_cidrs              = flatten(local.peer_tgws[*].vpc.network_cidrs)
   peer_tgws_all_vpc_routes                     = flatten(local.peer_tgws[*].vpc.routes)
-  peer_tgws_all_current_local_only_vpc_routes  = flatten(local.peer_tgws[*].vpc.current_local_only_routes)
   peer_tgws_all_vpc_routes_route_table_ids     = local.peer_tgws_all_vpc_routes[*].route_table_id
   peer_tgws_all_vpc_routes_transit_gateway_ids = local.peer_tgws_all_vpc_routes[*].transit_gateway_id
   peer_tgws_all_route_table_ids                = local.peer_tgws[*].route_table_id
   peer_tgws_all_ids                            = local.peer_tgws[*].id
-
-  route_format = "%s|%s"
 }
 
 ########################################################################################
@@ -120,9 +118,18 @@ locals {
       destination_cidr_block = route_table_id_and_local_tgw_network_cidr[1]
   }]
 
+  #local_tgws_all_vpc_routes_route_table_ids     = local.local_tgws_all_vpc_routes[*].route_table_id
+  # generate current existing local vpc routes
+  local_current_vpc_routes = flatten([
+    for this in local.local_tgws : [
+      for route_table_id_and_vpc_network_cidr in setproduct(this.vpc.routes[*].route_table_id, this.vpc.network_cidrs) : {
+        route_table_id         = route_table_id_and_vpc_network_cidr[0]
+        destination_cidr_block = route_table_id_and_vpc_network_cidr[1]
+  }]])
+
   # subtract all current existing local vpc routes from all local vpc routes
   local_tgw_all_new_vpc_routes_to_local_vpcs = {
-    for this in setsubtract(local.local_vpc_routes_to_local_tgws, local.local_tgws_all_current_local_only_vpc_routes) :
+    for this in setsubtract(local.local_vpc_routes_to_local_tgws, local.local_current_vpc_routes) :
     format(local.route_format, this.route_table_id, this.destination_cidr_block) => this
   }
 }
@@ -302,9 +309,17 @@ locals {
       destination_cidr_block = route_table_id_and_peer_tgw_network_cidr[1]
   }]
 
-  # subtract current existing local vpc routes from all local vpc routes
+  # generate current existing peer vpc routes
+  peer_current_vpc_routes = flatten([
+    for this in local.peer_tgws : [
+      for route_table_id_and_vpc_network_cidr in setproduct(this.vpc.routes[*].route_table_id, this.vpc.network_cidrs) : {
+        route_table_id         = route_table_id_and_vpc_network_cidr[0]
+        destination_cidr_block = route_table_id_and_vpc_network_cidr[1]
+  }]])
+
+  # subtract current existing peer vpc routes from all peer vpc routes
   peer_tgw_all_new_vpc_routes_to_peer_vpcs = {
-    for this in setsubtract(local.peer_vpc_routes_to_peer_tgws, local.peer_tgws_all_current_local_only_vpc_routes) :
+    for this in setsubtract(local.peer_vpc_routes_to_peer_tgws, local.peer_current_vpc_routes) :
     format(local.route_format, this.route_table_id, this.destination_cidr_block) => this
   }
 }

--- a/networking/tgw_super_router_for_tgw_centralized_router/variables.tf
+++ b/networking/tgw_super_router_for_tgw_centralized_router/variables.tf
@@ -31,10 +31,6 @@ variable "super_router" {
             destination_cidr_block = string
             transit_gateway_id     = string
           }))
-          current_local_only_routes = list(object({
-            route_table_id         = string
-            destination_cidr_block = string
-          }))
         })
       })), {})
     })
@@ -55,10 +51,6 @@ variable "super_router" {
             route_table_id         = string
             destination_cidr_block = string
             transit_gateway_id     = string
-          }))
-          current_local_only_routes = list(object({
-            route_table_id         = string
-            destination_cidr_block = string
           }))
         })
       })), {})

--- a/networking/transit_gateway_centralized_router_for_tiered_vpc_ng/outputs.tf
+++ b/networking/transit_gateway_centralized_router_for_tiered_vpc_ng/outputs.tf
@@ -42,20 +42,12 @@ locals {
       destination_cidr_block = this.destination_cidr_block
       transit_gateway_id     = this.transit_gateway_id
   }]
-  # generate current existing local vpc routes for use by super router
-  # it helps to generate (know) routes that would already exist for all vpcs
-  vpc_current_local_only_routes = [
-    for route_table_id_and_vpc_network_cidr in setproduct(local.vpc_routes[*].route_table_id, local.vpc_network_cidrs) : {
-      route_table_id         = route_table_id_and_vpc_network_cidr[0]
-      destination_cidr_block = route_table_id_and_vpc_network_cidr[1]
-  }]
 }
 
 output "vpc" {
   value = {
-    names                     = local.vpc_names
-    network_cidrs             = local.vpc_network_cidrs
-    routes                    = local.vpc_routes
-    current_local_only_routes = local.vpc_current_local_only_routes
+    names         = local.vpc_names
+    network_cidrs = local.vpc_network_cidrs
+    routes        = local.vpc_routes
   }
 }


### PR DESCRIPTION
Moving the generate current existing vpc routes into centralized router was a bad idea because the super router abstraction was leaking into centralized router. even though i can move the following calculation into centralized router doesnt mean i should have. 
ie
```
 # generate current existing local vpc routes
  local_current_vpc_routes = flatten([
    for this in local.local_tgws : [
      for vpc_network_cidr in this.vpc.network_cidrs : [
        for rtb_id_and_vpc_network_cidr in setproduct(this.vpc.routes[*].route_table_id, [vpc_network_cidr]) : {
          route_table_id         = rtb_id_and_vpc_network_cidr[0]
          destination_cidr_block = rtb_id_and_vpc_network_cidr[1]
  }]]])
```
see https://github.com/JudeQuintana/terraform-modules/pull/15

super router should know how to do this itself and not put the burden on centralized router. but the calculation looks much better this time around. it wasnt immediately clear at first how it should look and if it should stay in super router.  but after alot of code clean up it's more clear what it should look like. so instead of shooting for efficiency only (removing as much for loops as i can with the same behavior) i should also shoot for making sure calculations in the module makes the most sense without having to jump around into other modules to keep the abstraction in check. 


