### PR TITLE
remove unnecessary lifecycle ignore

### DIFF
--- a/networking/tgw_super_router_for_tgw_centralized_router/routing.tf
+++ b/networking/tgw_super_router_for_tgw_centralized_router/routing.tf
@@ -167,10 +167,6 @@ resource "aws_ec2_transit_gateway_route" "this_local_tgw_routes_to_vpcs_in_peer_
   transit_gateway_route_table_id = each.value.route_table_id
   destination_cidr_block         = each.value.destination_cidr_block
   transit_gateway_attachment_id  = lookup(aws_ec2_transit_gateway_peering_attachment_accepter.this_local_to_locals, lookup(local.local_tgw_route_table_id_to_local_tgw_id, each.value.route_table_id)).id
-
-  lifecycle {
-    ignore_changes = [transit_gateway_attachment_id]
-  }
 }
 
 locals {
@@ -357,10 +353,6 @@ resource "aws_ec2_transit_gateway_route" "this_peer_tgw_routes_to_vpcs_in_peer_t
   transit_gateway_route_table_id = each.value.route_table_id
   destination_cidr_block         = each.value.destination_cidr_block
   transit_gateway_attachment_id  = lookup(aws_ec2_transit_gateway_peering_attachment_accepter.this_peer_to_peers, lookup(local.peer_tgw_route_table_id_to_peer_tgw_id, each.value.route_table_id)).id
-
-  lifecycle {
-    ignore_changes = [transit_gateway_attachment_id]
-  }
 }
 
 locals {

--- a/networking/tiered_vpc_ng/private.tf
+++ b/networking/tiered_vpc_ng/private.tf
@@ -65,10 +65,6 @@ resource "aws_route" "this_private_route_out" {
   destination_cidr_block = local.route_any_cidr
   route_table_id         = lookup(aws_route_table.this_private, each.key).id
   nat_gateway_id         = lookup(aws_nat_gateway.this_public, each.key).id
-
-  lifecycle {
-    ignore_changes = [route_table_id, nat_gateway_id]
-  }
 }
 
 # associate each private subnet to its respective AZ's route table
@@ -77,8 +73,4 @@ resource "aws_route_table_association" "this_private" {
 
   subnet_id      = lookup(aws_subnet.this_private, each.key).id
   route_table_id = lookup(aws_route_table.this_private, lookup(local.private_subnet_cidr_to_az, each.key)).id
-
-  lifecycle {
-    ignore_changes = [subnet_id, route_table_id]
-  }
 }

--- a/networking/tiered_vpc_ng/public.tf
+++ b/networking/tiered_vpc_ng/public.tf
@@ -76,13 +76,6 @@ resource "aws_route_table_association" "this_public" {
 
   subnet_id      = lookup(aws_subnet.this_public, each.key).id
   route_table_id = aws_route_table.this_public.id
-
-  lifecycle {
-    # route_table_id is not needed here because the value
-    # is not a part of the for_each iteration and therefore
-    # wont trigger forcing a new resource
-    ignore_changes = [subnet_id]
-  }
 }
 
 #######################################################
@@ -140,8 +133,4 @@ resource "aws_nat_gateway" "this_public" {
   })
 
   depends_on = [aws_internet_gateway.this]
-
-  lifecycle {
-    ignore_changes = [allocation_id, subnet_id]
-  }
 }


### PR DESCRIPTION
- the lifecycle ignore  on certain resources attributes in `tiered-vpc-ng` were needed at one point but the problem it was solving no longer seems to be an issue. ie `aws_route_table_association`, `aws_route`, `aws_nat_gateway` would want to recreate existing  adjacent resources when adding VPCs, AZs, or subnets but this is no longer the case and are NOT needed. Maybe the behavior was updated in the provider for each resource exhibiting the behavior.

- same for `super-router`'s `aws_ec2_transit_gateway_route` resource. 
  - the ones remaning ARE needed for `aws_ec2_transit_gateway_route_table_association` and `aws_ec2_transit_gateway_peering_attachment_accepter` and exhibit the behavior above.

- the less lifecycle ignore in use the better.