### PR TITLE
build ipv6 versions of networking modules

### DIFF
--- a/networking/ipv6/readme.md
+++ b/networking/ipv6/readme.md
@@ -1,0 +1,11 @@
+# TODO
+
+now that aws is charging for public IPv4 at an hourly rate (~$3.60 per month)
+https://aws.amazon.com/blogs/aws/new-aws-public-ipv4-address-charge-public-ip-insights/
+
+its proabably a good idea to build IPv6 versions of:
+- tiered_vpc_ng
+- centralized_router
+- super_router
+- intra_vpc_security_group_rules
+- super_intra_vpc_security_group_rules


### PR DESCRIPTION
# TODO

now that aws is charging for public IPv4 at an hourly rate (~$3.60 per month)
https://aws.amazon.com/blogs/aws/new-aws-public-ipv4-address-charge-public-ip-insights/

its proabably a good idea to build IPv6 versions of my [published modules](https://registry.terraform.io/namespaces/JudeQuintana):
- tiered_vpc_ng
- centralized_router
- super_router
- intra_vpc_security_group_rules
- super_intra_vpc_security_group_rules